### PR TITLE
fix: correct build script for vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "echo 'not required' && exit 0",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint"
   },


### PR DESCRIPTION
The build script in package.json was incorrect, preventing Vercel from building the Next.js application. This change corrects the script to `next build`, which will allow the project to be deployed successfully.